### PR TITLE
Fix broken image links using Jekyll Liquid syntax

### DIFF
--- a/src/content/posts/caching-in-datacenters.md
+++ b/src/content/posts/caching-in-datacenters.md
@@ -65,7 +65,7 @@ making it way ahead of persistent media when it comes to performance.
 
 The following figure captures the relative "closeness" of data at different
 locations:
-  ![data access speed]({{ "/assets/img/data_access_speed.jpg" | prepend: site.baseurl }})
+  ![data access speed](/assets/img/data_access_speed.jpg)
 
 
 The typical datacenter infrastructure has a few implications:

--- a/src/content/posts/why-pelikan.md
+++ b/src/content/posts/why-pelikan.md
@@ -134,7 +134,7 @@ deterministic memory allocation, wait-less logging/stats, and other carefully
 chosen design patterns. For more details, see [this talk](https://www.infoq.com/presentations/pelikan)
 at QConSF 2016.
 
-  ![pelikan_twemcache_latency]({{ "/assets/img/pelikan_twemcache_latency.jpg" | prepend: site.baseurl }})
+  ![pelikan_twemcache_latency](/assets/img/pelikan_twemcache_latency.jpg)
 
 Side-by-side benchmarking using an identical [rpc-perf](https://github.com/twitter/rpc-perf)
 setup that emulates cache traffic to a major cache cluster shows that Pelikan


### PR DESCRIPTION
## Summary
- `why-pelikan.md` and `caching-in-datacenters.md` still used Jekyll's `{{ "..." | prepend: site.baseurl }}` Liquid syntax for image URLs, which Astro doesn't interpret — the raw template tag rendered in the page instead of the image.
- Replaced with direct `/assets/img/...` paths. The image files already live under `public/assets/img/`, which Astro serves at the site root.

## Test plan
- [ ] Visit `/blog/why-pelikan/` and confirm the `pelikan_twemcache_latency.jpg` image renders.
- [ ] Visit `/blog/caching-in-datacenters/` and confirm the `data_access_speed.jpg` image renders.


---
_Generated by [Claude Code](https://claude.ai/code/session_015WJ6UExXiH1gmuxbtBHZ6s)_